### PR TITLE
Fix incompatible timestamp formats in get_sensor_data

### DIFF
--- a/fourinsight/campaigns/campaign.py
+++ b/fourinsight/campaigns/campaign.py
@@ -177,14 +177,12 @@ class GenericCampaign:
             if cond(channel["Channel"])
         }
 
-        # switch to walrus operator when possible
-        if start is None and not pd.isna(self.general()["Start Date"]):
-            start = self.general()["Start Date"]
+        if start is None and not pd.isna(start_general := self.general()["Start Date"]):
+            start = start_general
 
         if end is None:
-            # switch to walrus operator when possible
-            if not pd.isna(self.general()["End Date"]):
-                end = self.general()["End Date"]
+            if not pd.isna(end_general := self.general()["End Date"]):
+                end = end_general
             else:
                 end = "now"
 

--- a/fourinsight/campaigns/campaign.py
+++ b/fourinsight/campaigns/campaign.py
@@ -184,7 +184,7 @@ class GenericCampaign:
         if end is None:
             # switch to walrus operator when possible
             if not pd.isna(self.general()["End Date"]):
-                end = self.general()["End Date"] + pd.Timedelta("1D")
+                end = self.general()["End Date"]
             else:
                 end = "now"
 

--- a/tests/test_campaign.py
+++ b/tests/test_campaign.py
@@ -276,8 +276,8 @@ class Test_GenericCampaign:
     @patch("fourinsight.campaigns.campaign.download_sensor_data")
     def test_get_sensor_data_whitelist(self, mock_dl_data, generic_campaign):
         campaign = generic_campaign
-        start = pd.to_datetime("2019-01-01")
-        end = pd.to_datetime("2019-02-01")
+        start = "2019-01-01T00:00:00"
+        end = "2019-02-01T00:00:00"
         campaign._campaign = {"Start Date": start, "End Date": end}
         channels = [
             {"Channel": "c1", "Timeseries id": "ts1"},
@@ -286,7 +286,7 @@ class Test_GenericCampaign:
         campaign.get_sensor_data("dummy_client", {"Channels": channels}, filter_=["c2"])
 
         mock_dl_data.assert_called_once_with(
-            "dummy_client", {"c2": "ts2"}, start=start, end=end + pd.to_timedelta("1D")
+            "dummy_client", {"c2": "ts2"}, start="2019-01-01T00:00:00", end="2019-02-01T00:00:00"
         )
 
     @patch("fourinsight.campaigns.campaign.download_sensor_data")

--- a/tests/test_campaign.py
+++ b/tests/test_campaign.py
@@ -294,8 +294,8 @@ class Test_GenericCampaign:
         self, mock_dl_data, generic_campaign
     ):
         campaign = generic_campaign
-        start = pd.to_datetime("2019-01-01")
-        end = pd.to_datetime("2019-02-01")
+        start = "2019-01-01T00:00:00"
+        end = "2019-02-01T00:00:00"
         campaign._campaign = {"Start Date": start, "End Date": end}
         channels = [
             {"Channel": "Ax", "Timeseries id": "ts1"},
@@ -306,7 +306,7 @@ class Test_GenericCampaign:
         )
 
         mock_dl_data.assert_called_once_with(
-            "dummy_client", {"Gx": "ts2"}, start=start, end=end + pd.to_timedelta("1D")
+            "dummy_client", {"Gx": "ts2"}, start="2019-01-01T00:00:00", end="2019-02-01T00:00:00"
         )
 
     @patch("fourinsight.campaigns.campaign.pd.isna", return_value=True)

--- a/tests/test_campaign.py
+++ b/tests/test_campaign.py
@@ -256,8 +256,8 @@ class Test_GenericCampaign:
     @patch("fourinsight.campaigns.campaign.download_sensor_data", return_value="abc")
     def test_get_sensor_data(self, mock_dl_data, generic_campaign):
         campaign = generic_campaign
-        start = pd.to_datetime("2019-01-01")
-        end = pd.to_datetime("2019-02-01")
+        start = "2019-01-01T00:00:00"
+        end = "2019-02-01T00:00:00"
         campaign._campaign = {"Start Date": start, "End Date": end}
         channels = [
             {"Channel": "c1", "Timeseries id": "ts1"},
@@ -268,8 +268,8 @@ class Test_GenericCampaign:
         mock_dl_data.assert_called_once_with(
             "dummy_client",
             {"c1": "ts1", "c2": "ts2"},
-            start=start,
-            end=end + pd.to_timedelta("1D"),
+            start="2019-01-01T00:00:00",
+            end="2019-02-01T00:00:00",
         )
         assert result == "abc"
 

--- a/tests/test_campaign.py
+++ b/tests/test_campaign.py
@@ -286,7 +286,10 @@ class Test_GenericCampaign:
         campaign.get_sensor_data("dummy_client", {"Channels": channels}, filter_=["c2"])
 
         mock_dl_data.assert_called_once_with(
-            "dummy_client", {"c2": "ts2"}, start="2019-01-01T00:00:00", end="2019-02-01T00:00:00"
+            "dummy_client",
+            {"c2": "ts2"},
+            start="2019-01-01T00:00:00",
+            end="2019-02-01T00:00:00",
         )
 
     @patch("fourinsight.campaigns.campaign.download_sensor_data")
@@ -306,7 +309,10 @@ class Test_GenericCampaign:
         )
 
         mock_dl_data.assert_called_once_with(
-            "dummy_client", {"Gx": "ts2"}, start="2019-01-01T00:00:00", end="2019-02-01T00:00:00"
+            "dummy_client",
+            {"Gx": "ts2"},
+            start="2019-01-01T00:00:00",
+            end="2019-02-01T00:00:00",
         )
 
     @patch("fourinsight.campaigns.campaign.pd.isna", return_value=True)


### PR DESCRIPTION
### This PR is related to user story DST-459

## Description
Fix TypeError raised for incompatible timestamp formats.

## Checklist
- [x] PR title is descriptive and fit for injection into release notes (see tips below)
- [x] Correct label(s) are used


PR title tips:
* Use imperative mood
* Describe the motivation for change, issue that has been solved or what has been improved - not how
* Examples:
  * Add functionality for Allan variance to sensor_4s.simulate
  * Upgrade to support Python 9.10
  * Remove MacOS from CI
  
