### PR TITLE
ESS-3819: Getting all timeseries linked to a campaign

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# JetBrains
+.idea

--- a/docs/user_guide/access_campaigns.rst
+++ b/docs/user_guide/access_campaigns.rst
@@ -58,11 +58,51 @@ Get list of sensors::
 
     campaign.sensors()
 
+Get list of timeseries::
+
+    campaign.timeseries()
+
+Each timeseries in the list includes general timeseries information, its metadata, and all 4insight connections.
+
+You can use Pandas to visualize the timeseries, connected to the campaign::
+
+    import pandas as pd
+    timeseries_list = campaign.timeseries()
+    pd.DataFrame(timeseries_list)
+
+To visualize weather timeseries, connected to the campaign::
+
+    import pandas as pd
+    timeseries_list = campaign.timeseries()
+    weather_timeseries = [
+        timeseries
+        for timeseries in timeseries_list
+        if timeseries["AttachedTo"]["Weather"]
+    ]
+    pd.DataFrame(weather_timeseries)
+
+To visualize timeseries connections in 4insight::
+
+    import pandas as pd
+    timeseries_list = campaign.timeseries()
+    connections = [
+        timeseries["AttachedTo"]
+        for timeseries in timeseries_list
+    ]
+    pd.DataFrame(connections)
+
 Some methods also support some filtering. For instance, to filter the list of sensors by ``Position``::
 
     lmrp_sensors = campaign.sensors(value="LMRP", by="Position")
 
+You can also find the timeseries by the corresponding sensor::
 
+    timeseries_list = campaign.timeseries()
+    sensor_timeseries = [
+        timeseries
+        for timeseries in timeseries_list
+        if 'sensor_name' in timeseries['AttachedTo']['Sensors']
+    ]
 
 .. _4Insight.io: https://4insight.io
 .. _DataReservoir.io: https://4subsea.com/products/4insight-data-analytics/

--- a/docs/user_guide/download_sensordata.rst
+++ b/docs/user_guide/download_sensordata.rst
@@ -46,3 +46,13 @@ Each sensor has a list of channels which in turn contain Timeseries ids. To acce
             if ts_id:
                 timeseries_ids.append(ts_id)
 
+Or using the ``timeseries`` function:
+
+.. code-block:: python
+
+    timeseries_list = campaign.timeseries()
+    timeseries_ids = [
+        timeseries['TimeSeriesID']
+        for timeseries in timeseries_list
+        if timeseries['AttachedTo']['Sensors']
+    ]

--- a/fourinsight/campaigns/campaign.py
+++ b/fourinsight/campaigns/campaign.py
@@ -26,6 +26,7 @@ class GenericCampaign:
         self._sensors = None
         self._events = None
         self._geotrack = None
+        self._timeseries = None
 
     def _lazy_load(self, attr, api_call, args=()):
         if getattr(self, attr) is None:
@@ -115,6 +116,23 @@ class GenericCampaign:
         if len(sensors) == 0:
             raise RuntimeError("No sensors matches the criteria.")
         return sensors
+
+    def timeseries(self):
+        """
+        Get all timeseries connected to the campaign, including weather ones.
+
+        Returns
+        -------
+        list[dict]
+            Timeseries list.
+            The list is ordered by timeseries created date descending.
+            The list includes timeseries metadata and 4insight connections (campaign, sensor, weather, etc.).
+
+        """
+        self._lazy_load(
+            "_timeseries", self._campaigns_api.get_timeseries, args=(self._campaign_id,)
+        )
+        return self._timeseries
 
     @staticmethod
     def _filter_dict_value_by(dict_, value, by):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,8 @@ from testdata.get_data import (
     SWIMOPS_CAMPAIGN_DATA_CAMELCASE,
     SWIMOPS_DATA,
     SWIMOPS_DATA_CAMELCASE,
+    TIMESERIES_DATA,
+    TIMESERIES_DATA_CAMELCASE,
 )
 
 DATA_MAP = {
@@ -41,6 +43,7 @@ DATA_MAP = {
     "https://api.4insight.io/v1.0/campaigns/1234": CAMPAIGN_DATA_SWIM,
     "https://api.4insight.io/v1.0/campaigns/test_generic_id": CAMPAIGN_DATA_GENERIC,
     "https://api.4insight.io/v1.0/campaigns/test_swim_id": CAMPAIGN_DATA_SWIM,
+    "https://api.4insight.io/v1.0/timeseries/search": TIMESERIES_DATA,
 }
 
 DATA_MAP_CAMELCASE = {
@@ -57,6 +60,7 @@ DATA_MAP_CAMELCASE = {
     "https://api.4insight.io/v1.0/campaigns/1234": CAMPAIGN_DATA_SWIM_CAMELCASE,
     "https://api.4insight.io/v1.0/campaigns/test_generic_id": CAMPAIGN_DATA_GENERIC_CAMELCASE,
     "https://api.4insight.io/v1.0/campaigns/test_swim_id": CAMPAIGN_DATA_SWIM_CAMELCASE,
+    "https://api.4insight.io/v1.0/timeseries/search": TIMESERIES_DATA_CAMELCASE,
 }
 
 
@@ -64,9 +68,10 @@ DATA_MAP_CAMELCASE = {
 def response():
     response = Mock()
     response._get_called_with_url = None
+    response._post_called_with_url = None
 
     def json_side_effect(*args, **kwargs):
-        url = response._get_called_with_url
+        url = response._get_called_with_url or response._post_called_with_url
         if not url:
             return
 
@@ -80,9 +85,10 @@ def response():
 def response_camelcase():
     response = Mock()
     response._get_called_with_url = None
+    response._post_called_with_url = None
 
     def json_side_effect(*args, **kwargs):
-        url = response._get_called_with_url
+        url = response._get_called_with_url or response._post_called_with_url
         if not url:
             return
 
@@ -107,7 +113,12 @@ def auth_session(response, session_headers):
         response._get_called_with_url = url
         return response
 
+    def post_side_effect(url, *args, **kwargs):
+        response._post_called_with_url = url
+        return response
+
     auth_session.get.side_effect = get_side_effect
+    auth_session.post.side_effect = post_side_effect
     return auth_session
 
 
@@ -121,5 +132,10 @@ def auth_session_camelcase(response_camelcase, session_headers):
         response_camelcase._get_called_with_url = url
         return response_camelcase
 
+    def post_side_effect(url, *args, **kwargs):
+        response_camelcase._post_called_with_url = url
+        return response_camelcase
+
     auth_session.get.side_effect = get_side_effect
+    auth_session.post.side_effect = post_side_effect
     return auth_session

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,12 +1,11 @@
-import json
 from unittest.mock import call
 
-import pandas as pd
 import pytest
 
 import fourinsight.campaigns as fc
 from fourinsight.campaigns.api import (
     CampaignsAPI,
+    _dict_get_ignoring_case,
     _dict_rename,
     _loc_to_float,
     _location_convert,
@@ -475,6 +474,308 @@ class Test_CampaignsAPI:
         ]
         assert expect == out
 
+    def test_get_timeseries_camelcase(
+        self,
+        campaigns_api_camelcase,
+        auth_session_camelcase,
+        response_camelcase,
+        headers_expect,
+    ):
+        campaign_id = "3306b986-664a-40a7-8495-787850745b03"
+        out = campaigns_api_camelcase.get_timeseries(campaign_id)
+        auth_session_camelcase.post.assert_called_once_with(
+            "https://api.4insight.io/v1.0/timeseries/search",
+            json={
+                "Campaigns": ["3306b986-664a-40a7-8495-787850745b03"],
+                "pageSize": 50,
+                "skip": 0,
+            },
+            headers=headers_expect,
+        )
+        response_camelcase.raise_for_status.assert_called()
+        response_camelcase.json.assert_called()
+        expect = [
+            {
+                "TimeSeriesID": "e0e0fcd8-3904-4fa1-bc3d-f62e0b27243f",
+                "Alias": None,
+                "Created": "2018-03-12T10:42:06.789+00:00",
+                "Created By": "string",
+                "Modified": "2018-03-12T10:42:06.789+00:00",
+                "Modified By": "string",
+                "Owner": "string",
+                "UoM": "string",
+                "Metadata": [
+                    {
+                        "Namespace": "string",
+                        "Key": "string",
+                        "Values": {
+                            "AdditionalProp1": "string",
+                            "AdditionalProp2": "string",
+                            "AdditionalProp3": "string",
+                        },
+                    }
+                ],
+                "AttachedTo": {
+                    "Vessels": ["string"],
+                    "Fields": [],
+                    "Wells": [],
+                    "Lines": [],
+                    "DataSources": [],
+                    "Instruments": [],
+                    "Sensors": ["string"],
+                    "Campaigns": ["string"],
+                    "Weather": [],
+                },
+            },
+            {
+                "TimeSeriesID": "065fe754-3ccd-4b99-9649-7a86f420cabc",
+                "Alias": "string",
+                "Created": "2018-03-12T10:43:01.771+00:00",
+                "Created By": "string",
+                "Modified": None,
+                "Modified By": None,
+                "Owner": "string",
+                "UoM": "string",
+                "Metadata": [
+                    {
+                        "Namespace": "string",
+                        "Key": "string",
+                        "Values": {
+                            "AdditionalProp1": "string",
+                            "AdditionalProp2": "string",
+                            "AdditionalProp3": "string",
+                        },
+                    },
+                    {
+                        "Namespace": "string",
+                        "Key": "string",
+                        "Values": {"AdditionalProp1": "string"},
+                    },
+                ],
+                "AttachedTo": {
+                    "Vessels": ["string"],
+                    "Fields": [],
+                    "Wells": [],
+                    "Lines": [],
+                    "DataSources": ["string"],
+                    "Instruments": [],
+                    "Sensors": [],
+                    "Campaigns": ["string", "title"],
+                    "Weather": [],
+                },
+            },
+            {
+                "TimeSeriesID": "cfbf5b22-08c0-4332-86ac-cd03f140243e",
+                "Alias": "string",
+                "Created": "2019-04-10T10:27:28.045+00:00",
+                "Created By": "string",
+                "Modified": None,
+                "Modified By": None,
+                "Owner": "string",
+                "UoM": "string",
+                "Metadata": [
+                    {
+                        "Namespace": "string",
+                        "Key": "string",
+                        "Values": {
+                            "AdditionalProp1": "string",
+                            "AdditionalProp2": "string",
+                            "AdditionalProp3": "string",
+                        },
+                    },
+                ],
+                "AttachedTo": {
+                    "Vessels": [],
+                    "Fields": ["string"],
+                    "Wells": [],
+                    "Lines": ["string"],
+                    "DataSources": [],
+                    "Instruments": ["string"],
+                    "Sensors": [],
+                    "Campaigns": ["string"],
+                    "Weather": [],
+                },
+            },
+            {
+                "TimeSeriesID": "6d9690ba-5a5d-4c3f-a5a7-2ebcb29decd0",
+                "Alias": "string",
+                "Created": "2025-11-13T10:16:56.979+00:00",
+                "Created By": "string",
+                "Modified": None,
+                "Modified By": None,
+                "Owner": "string",
+                "UoM": "string",
+                "Metadata": [
+                    {
+                        "Namespace": "string",
+                        "Key": "string",
+                        "Values": {"AdditionalProp1": "string"},
+                    }
+                ],
+                "AttachedTo": {
+                    "Vessels": ["string"],
+                    "Fields": [],
+                    "Wells": [],
+                    "Lines": [],
+                    "DataSources": [],
+                    "Instruments": [],
+                    "Sensors": [],
+                    "Campaigns": ["string"],
+                    "Weather": ["string"],
+                },
+            },
+        ]
+        assert expect == out
+
+    def test_get_timeseries(
+        self, campaigns_api, auth_session, response, headers_expect
+    ):
+        campaign_id = "3306b986-664a-40a7-8495-787850745b03"
+        out = campaigns_api.get_timeseries(campaign_id)
+        auth_session.post.assert_called_once_with(
+            "https://api.4insight.io/v1.0/timeseries/search",
+            json={
+                "Campaigns": ["3306b986-664a-40a7-8495-787850745b03"],
+                "pageSize": 50,
+                "skip": 0,
+            },
+            headers=headers_expect,
+        )
+        response.raise_for_status.assert_called()
+        response.json.assert_called()
+        expect = [
+            {
+                "TimeSeriesID": "e0e0fcd8-3904-4fa1-bc3d-f62e0b27243f",
+                "Alias": None,
+                "Created": "2018-03-12T10:42:06.789+00:00",
+                "Created By": "string",
+                "Modified": "2018-03-12T10:42:06.789+00:00",
+                "Modified By": "string",
+                "Owner": "string",
+                "UoM": "string",
+                "Metadata": [
+                    {
+                        "Namespace": "string",
+                        "Key": "string",
+                        "Values": {
+                            "AdditionalProp1": "string",
+                            "AdditionalProp2": "string",
+                            "AdditionalProp3": "string",
+                        },
+                    }
+                ],
+                "AttachedTo": {
+                    "Vessels": ["string"],
+                    "Fields": [],
+                    "Wells": [],
+                    "Lines": [],
+                    "DataSources": [],
+                    "Instruments": [],
+                    "Sensors": ["string"],
+                    "Campaigns": ["string"],
+                    "Weather": [],
+                },
+            },
+            {
+                "TimeSeriesID": "065fe754-3ccd-4b99-9649-7a86f420cabc",
+                "Alias": "string",
+                "Created": "2018-03-12T10:43:01.771+00:00",
+                "Created By": "string",
+                "Modified": None,
+                "Modified By": None,
+                "Owner": "string",
+                "UoM": "string",
+                "Metadata": [
+                    {
+                        "Namespace": "string",
+                        "Key": "string",
+                        "Values": {
+                            "AdditionalProp1": "string",
+                            "AdditionalProp2": "string",
+                            "AdditionalProp3": "string",
+                        },
+                    },
+                    {
+                        "Namespace": "string",
+                        "Key": "string",
+                        "Values": {"AdditionalProp1": "string"},
+                    },
+                ],
+                "AttachedTo": {
+                    "Vessels": ["string"],
+                    "Fields": [],
+                    "Wells": [],
+                    "Lines": [],
+                    "DataSources": ["string"],
+                    "Instruments": [],
+                    "Sensors": [],
+                    "Campaigns": ["string", "title"],
+                    "Weather": [],
+                },
+            },
+            {
+                "TimeSeriesID": "cfbf5b22-08c0-4332-86ac-cd03f140243e",
+                "Alias": "string",
+                "Created": "2019-04-10T10:27:28.045+00:00",
+                "Created By": "string",
+                "Modified": None,
+                "Modified By": None,
+                "Owner": "string",
+                "UoM": "string",
+                "Metadata": [
+                    {
+                        "Namespace": "string",
+                        "Key": "string",
+                        "Values": {
+                            "AdditionalProp1": "string",
+                            "AdditionalProp2": "string",
+                            "AdditionalProp3": "string",
+                        },
+                    },
+                ],
+                "AttachedTo": {
+                    "Vessels": [],
+                    "Fields": ["string"],
+                    "Wells": [],
+                    "Lines": ["string"],
+                    "DataSources": [],
+                    "Instruments": ["string"],
+                    "Sensors": [],
+                    "Campaigns": ["string"],
+                    "Weather": [],
+                },
+            },
+            {
+                "TimeSeriesID": "6d9690ba-5a5d-4c3f-a5a7-2ebcb29decd0",
+                "Alias": "string",
+                "Created": "2025-11-13T10:16:56.979+00:00",
+                "Created By": "string",
+                "Modified": None,
+                "Modified By": None,
+                "Owner": "string",
+                "UoM": "string",
+                "Metadata": [
+                    {
+                        "Namespace": "string",
+                        "Key": "string",
+                        "Values": {"AdditionalProp1": "string"},
+                    }
+                ],
+                "AttachedTo": {
+                    "Vessels": ["string"],
+                    "Fields": [],
+                    "Wells": [],
+                    "Lines": [],
+                    "DataSources": [],
+                    "Instruments": [],
+                    "Sensors": [],
+                    "Campaigns": ["string"],
+                    "Weather": ["string"],
+                },
+            },
+        ]
+        assert expect == out
+
     def test__get_sensors(self, campaigns_api, auth_session, response, headers_expect):
         out = campaigns_api._get_sensors("1234")
         auth_session.get.assert_called_once_with(
@@ -679,7 +980,7 @@ class Test_CampaignsAPI:
             "Dashboard Closed": "string",
             "Services Available": "string",
         }
-        expect == out
+        assert expect == out
 
     def test_get_swimops_campaign_camelcase(
         self,
@@ -712,7 +1013,7 @@ class Test_CampaignsAPI:
             "Dashboard Closed": "string",
             "Services Available": "string",
         }
-        expect == out
+        assert expect == out
 
     def test_get_swimops(self, campaigns_api, auth_session, response, headers_expect):
         out = campaigns_api.get_swimops()
@@ -787,7 +1088,7 @@ class Test_CampaignsAPI:
         assert campaigns_api_camelcase.get_campaign_type("1234") == "swim campaign"
 
 
-class Test__dict_rename:
+class Test_dict:
     def test_rename(self):
         dict_org = {
             "a": "this",
@@ -816,6 +1117,20 @@ class Test__dict_rename:
 
         dict_out = _dict_rename(dict_org, dict_map)
         assert dict_expected == dict_out
+
+    @pytest.mark.parametrize(
+        "key", ["lowercase", "camelCase", "PascalCase", "UPPERCASE"]
+    )
+    def test_get_case_insensitive(self, key):
+        dict_org = {key: "value"}
+        actual = _dict_get_ignoring_case(dict_org, key.upper())
+        assert actual == "value"
+
+    @pytest.mark.parametrize("value_default", [[], {}, 0, "string"])
+    def test_get_case_insensitive_default_vaule(self, value_default):
+        dict_org = {"key": "value"}
+        actual = _dict_get_ignoring_case(dict_org, "not_existing_key", value_default)
+        assert actual == value_default
 
 
 def test_loc_to_float_string():

--- a/tests/test_campaign.py
+++ b/tests/test_campaign.py
@@ -34,7 +34,7 @@ class Test_GenericCampaign:
         generic_campaign = GenericCampaign(auth_session, "1234")
 
         assert generic_campaign._campaign_id == "1234"
-        for attr in ["_campaign", "_events", "_sensors", "_geotrack"]:
+        for attr in ["_campaign", "_events", "_sensors", "_geotrack", "_timeseries"]:
             assert hasattr(generic_campaign, attr)
 
     def test_general(self, generic_campaign):
@@ -136,14 +136,15 @@ class Test_GenericCampaign:
             {
                 "SensorID": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
                 "Name": "string",
+                "Serial Number": "string",
                 "Position": "string",
-                "Distance From Wellhead": 0.0,
+                "Distance From Wellhead": 0,
                 "Direction X Axis": "string",
                 "Direction Z Axis": "string",
-                "Sampling Rate": 0.0,
+                "Sampling Rate": 0,
                 "Sensor Vendor": "string",
-                "Attached Time": pd.to_datetime("2021-08-12T11:51:19.667Z"),
-                "Detached Time": pd.to_datetime("2021-08-12T11:51:19.667Z"),
+                "Attached Time": "2021-08-12T11:51:19.667Z",
+                "Detached Time": "2021-08-12T11:51:19.667Z",
                 "Channels": [
                     {
                         "Channel": "string",
@@ -156,11 +157,12 @@ class Test_GenericCampaign:
             {
                 "SensorID": "<wh sensor id>",
                 "Name": "SN1234",
+                "Serial Number": "string",
                 "Position": "WH",
-                "Distance From Wellhead": 0.0,
+                "Distance From Wellhead": 0,
                 "Direction X Axis": "string",
                 "Direction Z Axis": "string",
-                "Sampling Rate": 0.0,
+                "Sampling Rate": 0,
                 "Sensor Vendor": "string",
                 "Attached Time": None,
                 "Detached Time": None,
@@ -174,7 +176,7 @@ class Test_GenericCampaign:
                 ],
             },
         ]
-        sensors_out == sensors_expect
+        assert sensors_out == sensors_expect
 
     def test_sensor_by_position(self, generic_campaign):
         sensors_out = generic_campaign.sensors(value="WH", by="Position")
@@ -191,6 +193,141 @@ class Test_GenericCampaign:
     def test_sensor_raises(self, generic_campaign):
         with pytest.raises(RuntimeError):
             generic_campaign.sensors(value="NOEXIST")
+
+    def test_timeseries(self, generic_campaign):
+        out = generic_campaign.timeseries()
+        expect = [
+            {
+                "TimeSeriesID": "e0e0fcd8-3904-4fa1-bc3d-f62e0b27243f",
+                "Alias": None,
+                "Created": "2018-03-12T10:42:06.789+00:00",
+                "Created By": "string",
+                "Modified": "2018-03-12T10:42:06.789+00:00",
+                "Modified By": "string",
+                "Owner": "string",
+                "UoM": "string",
+                "Metadata": [
+                    {
+                        "Namespace": "string",
+                        "Key": "string",
+                        "Values": {
+                            "AdditionalProp1": "string",
+                            "AdditionalProp2": "string",
+                            "AdditionalProp3": "string",
+                        },
+                    }
+                ],
+                "AttachedTo": {
+                    "Vessels": ["string"],
+                    "Fields": [],
+                    "Wells": [],
+                    "Lines": [],
+                    "DataSources": [],
+                    "Instruments": [],
+                    "Sensors": ["string"],
+                    "Campaigns": ["string"],
+                    "Weather": [],
+                },
+            },
+            {
+                "TimeSeriesID": "065fe754-3ccd-4b99-9649-7a86f420cabc",
+                "Alias": "string",
+                "Created": "2018-03-12T10:43:01.771+00:00",
+                "Created By": "string",
+                "Modified": None,
+                "Modified By": None,
+                "Owner": "string",
+                "UoM": "string",
+                "Metadata": [
+                    {
+                        "Namespace": "string",
+                        "Key": "string",
+                        "Values": {
+                            "AdditionalProp1": "string",
+                            "AdditionalProp2": "string",
+                            "AdditionalProp3": "string",
+                        },
+                    },
+                    {
+                        "Namespace": "string",
+                        "Key": "string",
+                        "Values": {"AdditionalProp1": "string"},
+                    },
+                ],
+                "AttachedTo": {
+                    "Vessels": ["string"],
+                    "Fields": [],
+                    "Wells": [],
+                    "Lines": [],
+                    "DataSources": ["string"],
+                    "Instruments": [],
+                    "Sensors": [],
+                    "Campaigns": ["string", "title"],
+                    "Weather": [],
+                },
+            },
+            {
+                "TimeSeriesID": "cfbf5b22-08c0-4332-86ac-cd03f140243e",
+                "Alias": "string",
+                "Created": "2019-04-10T10:27:28.045+00:00",
+                "Created By": "string",
+                "Modified": None,
+                "Modified By": None,
+                "Owner": "string",
+                "UoM": "string",
+                "Metadata": [
+                    {
+                        "Namespace": "string",
+                        "Key": "string",
+                        "Values": {
+                            "AdditionalProp1": "string",
+                            "AdditionalProp2": "string",
+                            "AdditionalProp3": "string",
+                        },
+                    },
+                ],
+                "AttachedTo": {
+                    "Vessels": [],
+                    "Fields": ["string"],
+                    "Wells": [],
+                    "Lines": ["string"],
+                    "DataSources": [],
+                    "Instruments": ["string"],
+                    "Sensors": [],
+                    "Campaigns": ["string"],
+                    "Weather": [],
+                },
+            },
+            {
+                "TimeSeriesID": "6d9690ba-5a5d-4c3f-a5a7-2ebcb29decd0",
+                "Alias": "string",
+                "Created": "2025-11-13T10:16:56.979+00:00",
+                "Created By": "string",
+                "Modified": None,
+                "Modified By": None,
+                "Owner": "string",
+                "UoM": "string",
+                "Metadata": [
+                    {
+                        "Namespace": "string",
+                        "Key": "string",
+                        "Values": {"AdditionalProp1": "string"},
+                    }
+                ],
+                "AttachedTo": {
+                    "Vessels": ["string"],
+                    "Fields": [],
+                    "Wells": [],
+                    "Lines": [],
+                    "DataSources": [],
+                    "Instruments": [],
+                    "Sensors": [],
+                    "Campaigns": ["string"],
+                    "Weather": ["string"],
+                },
+            },
+        ]
+        assert out == expect
 
     def test_filter_dict_value_by(self, generic_campaign):
         dict_list = [
@@ -336,6 +473,7 @@ class Test_SwimCampaign:
             "_events",
             "_sensors",
             "_geotrack",
+            "_timeseries",
             "_lowerstack",
             "_swim_operations",
         ]:

--- a/tests/testdata/get_data.py
+++ b/tests/testdata/get_data.py
@@ -355,6 +355,394 @@ LOWERSTACK_DATA_CAMELCASE = {
     ],
 }
 
+TIMESERIES_DATA = {
+    "TimeSeries": [
+        {
+            "TimeSeriesId": "e0e0fcd8-3904-4fa1-bc3d-f62e0b27243f",
+            "Alias": None,
+            "Created": "2018-03-12T10:42:06.789+00:00",
+            "CreatedBy": "string",
+            "Modified": "2018-03-12T10:42:06.789+00:00",
+            "ModifiedBy": "string",
+            "Organization": "string",
+            "UoM": "string",
+            "Metadata": [
+                {
+                    "Namespace": "string",
+                    "Key": "string",
+                    "Values": {
+                        "AdditionalProp1": "string",
+                        "AdditionalProp2": "string",
+                        "AdditionalProp3": "string",
+                    },
+                }
+            ],
+            "Entities": [
+                {
+                    "Id": "3306b986-664a-40a7-8495-787850745b03",
+                    "Title": "string",
+                    "Type": "GenericCampaign",
+                    "Children": [
+                        {
+                            "Id": "a732d51a-792e-4eb8-8014-0ff2ec8e4d12",
+                            "Title": "string",
+                            "Type": "Sensor",
+                            "Children": [],
+                        },
+                        {
+                            "Id": "5fdf3c38-80b4-4583-9a89-e589852492bf",
+                            "Title": "string",
+                            "Type": "Vessel",
+                            "Children": [],
+                        },
+                    ],
+                }
+            ],
+        },
+        {
+            "TimeSeriesId": "065fe754-3ccd-4b99-9649-7a86f420cabc",
+            "Alias": "string",
+            "Created": "2018-03-12T10:43:01.771+00:00",
+            "CreatedBy": "string",
+            "Modified": None,
+            "ModifiedBy": None,
+            "Organization": "string",
+            "UoM": "string",
+            "Metadata": [
+                {
+                    "Namespace": "string",
+                    "Key": "string",
+                    "Values": {
+                        "AdditionalProp1": "string",
+                        "AdditionalProp2": "string",
+                        "AdditionalProp3": "string",
+                    },
+                },
+                {
+                    "Namespace": "string",
+                    "Key": "string",
+                    "Values": {"AdditionalProp1": "string"},
+                },
+            ],
+            "Entities": [
+                {
+                    "Id": "3306b986-664a-40a7-8495-787850745b03",
+                    "Title": "string",
+                    "Type": "GenericCampaign",
+                    "Children": [],
+                },
+                {
+                    "Id": "4f272f8b-b784-4b36-ba19-db892022650a",
+                    "Title": "string",
+                    "Type": "Vessel",
+                    "Children": [
+                        {
+                            "Id": "b927e886-7338-45b1-8d56-69fb6024c058",
+                            "Title": "string",
+                            "Type": "DataSource",
+                            "Children": [],
+                        }
+                    ],
+                },
+                {
+                    "Id": "b927e886-7338-45b1-8d56-69fb6024c058",
+                    "Title": "string",
+                    "Type": "DataSource",
+                    "Children": [],
+                },
+                {
+                    "Id": "5e684419-a4bc-4a1a-8a7d-cf9018ce049f",
+                    "Title": "title",
+                    "Type": "GenericCampaign",
+                    "Children": [],
+                },
+            ],
+        },
+        {
+            "TimeSeriesId": "cfbf5b22-08c0-4332-86ac-cd03f140243e",
+            "Alias": "string",
+            "Created": "2019-04-10T10:27:28.045+00:00",
+            "CreatedBy": "string",
+            "Modified": None,
+            "ModifiedBy": None,
+            "Organization": "string",
+            "UoM": "string",
+            "Metadata": [
+                {
+                    "Namespace": "string",
+                    "Key": "string",
+                    "Values": {
+                        "AdditionalProp1": "string",
+                        "AdditionalProp2": "string",
+                        "AdditionalProp3": "string",
+                    },
+                },
+            ],
+            "Entities": [
+                {
+                    "Id": "c49a27bc-ceb0-4ead-bf59-32ade67d5dd3",
+                    "Title": "string",
+                    "Type": "Field",
+                    "Children": [
+                        {
+                            "Id": "748d25b5-1c20-4e4a-8dc0-7e6b128ea081",
+                            "Title": "string",
+                            "type": "Riser",
+                            "Children": [
+                                {
+                                    "Id": "48f97444-cf5b-49e8-aa9d-0e7bb00ce1e9",
+                                    "Title": "string",
+                                    "type": "Instrument",
+                                    "Children": [],
+                                }
+                            ],
+                        },
+                    ],
+                },
+                {
+                    "Id": "3306b986-664a-40a7-8495-787850745b03",
+                    "Title": "string",
+                    "type": "GenericCampaign",
+                    "Children": [],
+                },
+            ],
+        },
+        {
+            "TimeSeriesId": "6d9690ba-5a5d-4c3f-a5a7-2ebcb29decd0",
+            "Alias": "string",
+            "Created": "2025-11-13T10:16:56.979+00:00",
+            "CreatedBy": "string",
+            "Modified": None,
+            "ModifiedBy": None,
+            "Organization": "string",
+            "UoM": "string",
+            "Metadata": [
+                {
+                    "Namespace": "string",
+                    "Key": "string",
+                    "Values": {"AdditionalProp1": "string"},
+                }
+            ],
+            "Entities": [
+                {
+                    "Id": "3306b986-664a-40a7-8495-787850745b03",
+                    "Title": "string",
+                    "type": "GenericCampaign",
+                    "Children": [
+                        {
+                            "Id": "c2431c44-7232-4aaa-8a0b-0d8f2af108b4",
+                            "Title": "string",
+                            "type": "Vessel",
+                            "Children": [],
+                        },
+                    ],
+                },
+                {
+                    "Id": "ae029af1-746b-448b-9107-c2996ff78062",
+                    "Title": "string",
+                    "type": "Weather",
+                    "Children": [],
+                },
+            ],
+        },
+    ],
+    "TotalCount": 4,
+}
+
+TIMESERIES_DATA_CAMELCASE = {
+    "timeSeries": [
+        {
+            "timeSeriesId": "e0e0fcd8-3904-4fa1-bc3d-f62e0b27243f",
+            "alias": None,
+            "created": "2018-03-12T10:42:06.789+00:00",
+            "createdBy": "string",
+            "modified": "2018-03-12T10:42:06.789+00:00",
+            "modifiedBy": "string",
+            "organization": "string",
+            "uoM": "string",
+            "metadata": [
+                {
+                    "namespace": "string",
+                    "key": "string",
+                    "values": {
+                        "AdditionalProp1": "string",
+                        "AdditionalProp2": "string",
+                        "AdditionalProp3": "string",
+                    },
+                }
+            ],
+            "entities": [
+                {
+                    "id": "3306b986-664a-40a7-8495-787850745b03",
+                    "title": "string",
+                    "type": "GenericCampaign",
+                    "children": [
+                        {
+                            "id": "a732d51a-792e-4eb8-8014-0ff2ec8e4d12",
+                            "title": "string",
+                            "type": "Sensor",
+                            "children": [],
+                        },
+                        {
+                            "id": "5fdf3c38-80b4-4583-9a89-e589852492bf",
+                            "title": "string",
+                            "type": "Vessel",
+                            "children": [],
+                        },
+                    ],
+                }
+            ],
+        },
+        {
+            "timeSeriesId": "065fe754-3ccd-4b99-9649-7a86f420cabc",
+            "alias": "string",
+            "created": "2018-03-12T10:43:01.771+00:00",
+            "createdBy": "string",
+            "modified": None,
+            "modifiedBy": None,
+            "organization": "string",
+            "uoM": "string",
+            "metadata": [
+                {
+                    "namespace": "string",
+                    "key": "string",
+                    "values": {
+                        "AdditionalProp1": "string",
+                        "AdditionalProp2": "string",
+                        "AdditionalProp3": "string",
+                    },
+                },
+                {
+                    "namespace": "string",
+                    "key": "string",
+                    "values": {"AdditionalProp1": "string"},
+                },
+            ],
+            "entities": [
+                {
+                    "id": "3306b986-664a-40a7-8495-787850745b03",
+                    "title": "string",
+                    "type": "GenericCampaign",
+                    "children": [],
+                },
+                {
+                    "id": "4f272f8b-b784-4b36-ba19-db892022650a",
+                    "title": "string",
+                    "type": "Vessel",
+                    "children": [
+                        {
+                            "id": "b927e886-7338-45b1-8d56-69fb6024c058",
+                            "title": "string",
+                            "type": "DataSource",
+                            "children": [],
+                        }
+                    ],
+                },
+                {
+                    "id": "b927e886-7338-45b1-8d56-69fb6024c058",
+                    "title": "string",
+                    "type": "DataSource",
+                    "children": [],
+                },
+                {
+                    "id": "5e684419-a4bc-4a1a-8a7d-cf9018ce049f",
+                    "title": "title",
+                    "type": "GenericCampaign",
+                    "children": [],
+                },
+            ],
+        },
+        {
+            "timeSeriesId": "cfbf5b22-08c0-4332-86ac-cd03f140243e",
+            "alias": "string",
+            "created": "2019-04-10T10:27:28.045+00:00",
+            "createdBy": "string",
+            "modified": None,
+            "modifiedBy": None,
+            "organization": "string",
+            "uoM": "string",
+            "metadata": [
+                {
+                    "namespace": "string",
+                    "key": "string",
+                    "values": {
+                        "AdditionalProp1": "string",
+                        "AdditionalProp2": "string",
+                        "AdditionalProp3": "string",
+                    },
+                },
+            ],
+            "entities": [
+                {
+                    "id": "c49a27bc-ceb0-4ead-bf59-32ade67d5dd3",
+                    "title": "string",
+                    "type": "Field",
+                    "children": [
+                        {
+                            "id": "748d25b5-1c20-4e4a-8dc0-7e6b128ea081",
+                            "title": "string",
+                            "type": "Riser",
+                            "children": [
+                                {
+                                    "id": "48f97444-cf5b-49e8-aa9d-0e7bb00ce1e9",
+                                    "title": "string",
+                                    "type": "Instrument",
+                                    "children": [],
+                                }
+                            ],
+                        },
+                    ],
+                },
+                {
+                    "id": "3306b986-664a-40a7-8495-787850745b03",
+                    "title": "string",
+                    "type": "GenericCampaign",
+                    "children": [],
+                },
+            ],
+        },
+        {
+            "timeSeriesId": "6d9690ba-5a5d-4c3f-a5a7-2ebcb29decd0",
+            "alias": "string",
+            "created": "2025-11-13T10:16:56.979+00:00",
+            "createdBy": "string",
+            "modified": None,
+            "modifiedBy": None,
+            "organization": "string",
+            "uoM": "string",
+            "metadata": [
+                {
+                    "namespace": "string",
+                    "key": "string",
+                    "values": {"AdditionalProp1": "string"},
+                }
+            ],
+            "entities": [
+                {
+                    "id": "3306b986-664a-40a7-8495-787850745b03",
+                    "title": "string",
+                    "type": "GenericCampaign",
+                    "children": [
+                        {
+                            "id": "c2431c44-7232-4aaa-8a0b-0d8f2af108b4",
+                            "title": "string",
+                            "type": "Vessel",
+                            "children": [],
+                        },
+                    ],
+                },
+                {
+                    "id": "ae029af1-746b-448b-9107-c2996ff78062",
+                    "title": "string",
+                    "type": "Weather",
+                    "children": [],
+                },
+            ],
+        },
+    ],
+    "TotalCount": 4,
+}
+
 LOWERSTACK_DATA = {
     "CampaignId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
     "AnyFetchFailure": False,


### PR DESCRIPTION
### This PR is related to user story [ESS-3819](https://4insight.atlassian.net/browse/ESS-3819)

## Description
Add a new `campaign.timeseries()` function to get all timeseries connected to the campaign, including weather ones.

## Checklist
- [x] PR title is descriptive and fit for injection into release notes (see tips below)
- [x] Correct label(s) are used
  


[ESS-3819]: https://4insight.atlassian.net/browse/ESS-3819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ